### PR TITLE
Pull Instragram posts for specific user

### DIFF
--- a/app/controllers/followees_controller.rb
+++ b/app/controllers/followees_controller.rb
@@ -20,8 +20,11 @@ class FolloweesController < ApplicationController
 
   # pull a user's instagram posts
   def insta_user_posts 
-    user_id = "66"
-    response = HTTParty.get(INSTA_USER_POSTS_URI + user_id + "/media/recent/?access_token=" + ENV["INSTAGRAM_ACCESS_TOKEN"])
+    # will need to update this @user_id variable when we no longer are using a route to set params[:user] here
+    @user_id = params[:user]
+    response = HTTParty.get(INSTA_USER_POSTS_URI + @user_id + "/media/recent/?count=3&access_token=" + ENV["INSTAGRAM_ACCESS_TOKEN"])
+  
+    @insta_user_posts = response["data"]
   end
 
   def insta_search; end

--- a/app/controllers/followees_controller.rb
+++ b/app/controllers/followees_controller.rb
@@ -1,5 +1,6 @@
 class FolloweesController < ApplicationController
   INSTA_URI = "https://api.instagram.com/v1/users/search?"
+  INSTA_USER_POSTS_URI = "https://api.instagram.com/v1/users/"
   before_action :find, only: [:destroy]
 
   def new
@@ -24,6 +25,14 @@ class FolloweesController < ApplicationController
     #       "id": "66",
     #       "last_name": "Dorsey"
     #   }} ------------------------
+  end
+
+  # pull a user's instagram posts
+  def insta_user_posts 
+    user_id = "66"
+    response = HTTParty.get(INSTA_USER_POSTS_URI + user_id + "/media/recent/?access_token=" + ENV["INSTAGRAM_ACCESS_TOKEN"])
+
+
   end
 
   private

--- a/app/views/followees/insta_user_posts.html.erb
+++ b/app/views/followees/insta_user_posts.html.erb
@@ -1,0 +1,12 @@
+<!-- This view is for de-bugging. Prob will delete this view later -->
+
+
+<h1>Instagram User <%= @user_id %>'s Posts:</h1>
+  <% @insta_user_posts.each do |post| %>
+    <%= image_tag post["images"]["low_resolution"]["url"] %>
+    <%= post["caption"]["text"] %>
+<% end %>
+<br>
+
+<br>
+<%= link_to "Back to Home", root_path, class: "btn-sm btn-primary" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,6 @@ Rails.application.routes.draw do
   post 'search_twitter', to: 'home#twitter_users_redirect', as: 'twitter_users_redirect'
   get 'twitter_users/:user', to: 'home#twitter_users', as: 'twitter_users'
 
+  get 'insta_user_posts', to: 'followees#insta_user_posts', as: "iuser_posts"
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   post 'search_twitter', to: 'home#twitter_users_redirect', as: 'twitter_users_redirect'
   get 'twitter_users/:user', to: 'home#twitter_users', as: 'twitter_users'
 
-  get 'insta_user_posts', to: 'followees#insta_user_posts', as: "iuser_posts"
+
+  # this route is for de-bugging fetching a user's posts. Prob will delete later
+  get '/instagram/:user/posts', to: 'followees#insta_user_posts', as: "iuser_posts"
 
 end


### PR DESCRIPTION
Can now pull Instagram post data for a specific user from the Instagram API.

This includes a route and view that I used to test that the method was working. We will ultimately delete this view and route when we hook the method up to the "update feed" functionality later.
