### PR TITLE
Ka/unsubscribe from search

### DIFF
--- a/app/controllers/followees_controller.rb
+++ b/app/controllers/followees_controller.rb
@@ -5,7 +5,7 @@ class FolloweesController < ApplicationController
 
   before_action :find, only: [:destroy]
   # helper_method :get_embedded_html_instagram
-  helper_method :private_user?, :already_following?
+  helper_method :private_user?, :currently_following?, :find_subscription_id
 
   include ActionView::Helpers::OutputSafetyHelper
 
@@ -47,7 +47,21 @@ class FolloweesController < ApplicationController
     return privacy_boolean
   end
 
-  def already_following?(followee_id)
-    @current_user.followees.find_by(native_id: followee_id) ? true : false
+  def currently_following?(native_id)
+    followee = find_followee(native_id)
+    if followee
+      @current_user.subscriptions.active_for_this_followee(followee.id).empty? ? false : true
+    else
+      return false
+    end
+  end
+
+  def find_subscription_id(native_id)
+    followee = find_followee(native_id)
+    subscription_id_to_unsubscribe = @current_user.subscriptions.active_for_this_followee(followee.id).first
+  end
+
+  def find_followee(native_id)
+    Followee.find_by(native_id: native_id)
   end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -6,7 +6,8 @@ class SubscriptionsController < ApplicationController
     followee = Followee.find_or_create_by(followee_params)
     Subscription.find_or_create_subscription(@current_user, followee)
 
-    redirect_to root_path
+    # redirect_to root_path
+    redirect_to :back
   end
 
   def index
@@ -23,7 +24,8 @@ class SubscriptionsController < ApplicationController
     # adds current time to unsubscribe_date
     subscription = Subscription.find(params[:id])
     subscription.update!(unsubscribe_date: Time.now)
-    redirect_to subscriptions_path, flash[:notice] = "You have successfully unsubscribed."
+    # redirect_to subscriptions_path, flash[:notice] = "You have successfully unsubscribed."
+    redirect_to :back
   end
 
   private

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,6 +8,7 @@ class Subscription < ActiveRecord::Base
 
   # Scopes ------------------------------
   scope :active, -> { where(unsubscribe_date: nil) }
+  scope :active_for_this_followee, -> (followee_id) { where( { followee_id: followee_id, unsubscribe_date: nil}) }
 
   def self.find_or_create_subscription(current_user, followee)
     subscription = self.find_or_initialize_by(

--- a/app/views/followees/search.html.erb
+++ b/app/views/followees/search.html.erb
@@ -44,8 +44,8 @@
                 <%= link_to "Private User", root_path, class: "btn btn-default disabled"%>
               
               <!-- Can 'unsubscribes' from user accounts you already follow -->
-              <% elsif already_following?(user["id"]) %>
-                <%= link_to "Unsubscribe", "#", class: "btn btn-danger" %>
+              <% elsif currently_following?(user["id"]) %>
+                <%= link_to "Unsubscribe", unsubscribe_path(find_subscription_id(user["id"])), method: :put, class: "btn btn-danger" %>
 
               <!-- Can subscribe to public user accounts -->
               <% else %>

--- a/app/views/followees/search.html.erb
+++ b/app/views/followees/search.html.erb
@@ -66,8 +66,8 @@
               @<%= user.screen_name %>
 
               <!-- Can 'unsubscribes' from user accounts you already follow -->
-              <% if already_following?(user.id) %>
-                <%= link_to "Unsubscribe", "#", class: "btn btn-danger" %>
+              <% if currently_following?(user.id) %>
+                <%= link_to "Unsubscribe", unsubscribe_path(find_subscription_id(user.id)), method: :put, class: "btn btn-danger" %>
 
               <!-- Can subscribe to public user accounts -->
               <% else %>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -13,7 +13,7 @@
       <% end %>
       <%= image_tag(f.avatar_url, class: "img-thumbnail", size: "50x50") %>
       <%= f.handle %>
-      <%= link_to "Unsubscribe", unsubscribe_path(f.subscriptions.where(user_id: @current_user.id).first.id), method: :put, class: "btn btn-danger btn-sm" %>
+      <%= link_to "Unsubscribe", unsubscribe_path(f.subscriptions.where( { user_id: @current_user.id, unsubscribe_date: nil } ).first.id), method: :put, class: "btn btn-danger btn-sm" %>
     </li>
   <% end %>
   </ul>


### PR DESCRIPTION
Can now unsubscribe from a followee from the search results page. It identifies the current subscription for that user to unsubscribe from if you click the 'unsubscribe' button. It also does this on the 'my subscriptions' page when you click on 'unsubscribe'.

Fixed merge conflicts.
